### PR TITLE
fix: Header에서 노트북 API 중복 호출 제거 (#68)

### DIFF
--- a/src/containers/notebook/utils/use-notebook.ts
+++ b/src/containers/notebook/utils/use-notebook.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { getNotebook, type Notebook } from '@/shared/api/notebook.api'
+import { useNotebookMetaStore } from '@/shared/store/notebook-meta-store'
 
 interface NotebookState {
   notebook: Notebook | null
@@ -11,6 +12,8 @@ interface NotebookState {
 }
 
 export const useNotebook = (notebookId: number): NotebookState => {
+  const setMeta = useNotebookMetaStore((s) => s.setMeta)
+  const clearMeta = useNotebookMetaStore((s) => s.clear)
   const [state, setState] = useState<NotebookState>({
     notebook: null,
     isLoading: true,
@@ -20,12 +23,16 @@ export const useNotebook = (notebookId: number): NotebookState => {
 
   useEffect(() => {
     getNotebook(notebookId)
-      .then((notebook) => setState({ notebook, isLoading: false, is404: false, isError: false }))
+      .then((notebook) => {
+        setState({ notebook, isLoading: false, is404: false, isError: false })
+        setMeta(notebookId, notebook.title)
+      })
       .catch((err) => {
         const is404 = err?.response?.status === 404
         setState({ notebook: null, isLoading: false, is404, isError: !is404 })
+        clearMeta()
       })
-  }, [notebookId])
+  }, [notebookId, setMeta, clearMeta])
 
   return state
 }

--- a/src/shared/components/layout/header/index.tsx
+++ b/src/shared/components/layout/header/index.tsx
@@ -1,53 +1,18 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { Button } from '@/shared/components/ui/button'
 import { ThemeToggle } from '@/shared/components/theme-toggle'
-import { ErrorAlert, type ErrorAlertState } from '@/shared/components'
 import * as s from './index.style'
 import { useUserStore } from '@/shared/store/user-store'
-import { useRouter, useParams } from 'next/navigation'
-import { getNotebook } from '@/shared/api/notebook.api'
+import { useRouter } from 'next/navigation'
+import { useNotebookMetaStore } from '@/shared/store/notebook-meta-store'
 
 export function Header() {
   const router = useRouter()
-  const params = useParams()
   const user = useUserStore((state) => state.user)
-  const [notebookName, setNotebookName] = useState<string | null>(null)
-  const [error, setError] = useState<ErrorAlertState | null>(null)
-
-  const notebookId = params && typeof params.id === 'string' ? Number(params.id) : null
-
-  useEffect(() => {
-    let isMounted = true
-
-    const fetchNotebookName = async () => {
-      if (!notebookId) {
-        if (isMounted) setNotebookName(null)
-        return
-      }
-
-      try {
-        const notebook = await getNotebook(notebookId)
-        if (isMounted) {
-          setNotebookName(notebook.title)
-        }
-      } catch {
-        if (isMounted) {
-          setNotebookName(null)
-          setError({ title: '노트북 정보 실패', description: '노트북 이름을 불러오지 못했습니다.' })
-        }
-      }
-    }
-
-    fetchNotebookName()
-
-    return () => {
-      isMounted = false
-    }
-  }, [notebookId])
+  const notebookName = useNotebookMetaStore((s) => s.title)
 
   const handleLogout = () => {
     useUserStore.getState().clearUser()
@@ -56,7 +21,6 @@ export function Header() {
 
   return (
     <>
-      <ErrorAlert error={error} onClose={() => setError(null)} />
       <header className={s.header()}>
         <div className={s.container()}>
           <div className={s.leftSection()}>

--- a/src/shared/store/notebook-meta-store.ts
+++ b/src/shared/store/notebook-meta-store.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand'
+
+interface NotebookMetaState {
+  notebookId: number | null
+  title: string | null
+  setMeta: (notebookId: number, title: string) => void
+  clear: () => void
+}
+
+export const useNotebookMetaStore = create<NotebookMetaState>((set) => ({
+  notebookId: null,
+  title: null,
+  setMeta: (notebookId, title) => set({ notebookId, title }),
+  clear: () => set({ notebookId: null, title: null }),
+}))


### PR DESCRIPTION
Header가 getNotebook을 직접 호출하던 것을 제거하고,
useNotebook 훅에서 fetch한 데이터를 notebook-meta-store를 통해 공유하도록 변경.